### PR TITLE
Change middleware order to skp auth for swagger

### DIFF
--- a/ChargesApi/Startup.cs
+++ b/ChargesApi/Startup.cs
@@ -224,9 +224,9 @@ namespace ChargesApi
                         $"{ApiName}-api {apiVersionDescription.GetFormattedApiVersion()}");
                 }
             });
+            app.UseSwagger();
             app.UseGoogleGroupAuthorization();
             app.UseMiddleware<ExceptionMiddleware>();
-            app.UseSwagger();
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

When we try to open Swagger without JWT token, we receive an 401 error

### *What changes have we introduced*

Change middlewares order to have `UseGoogleGroupAuthorization` after `UseSwagger`
