### PR TITLE
Implement dynamodb autoscaling - development

### DIFF
--- a/terraform/development/dynamodb.tf
+++ b/terraform/development/dynamodb.tf
@@ -1,39 +1,78 @@
 resource "aws_dynamodb_table" "chargesapi_dynamodb_table" {
-    name                  = "Charges"
-    billing_mode          = "PROVISIONED"
-    read_capacity         = 100
-    write_capacity        = 100
-    hash_key              = "target_id"
-    range_key             = "id"
-    autoscaling_enabled   = true
+  name           = "Charges"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 100
+  write_capacity = 100
+  hash_key       = "target_id"
+  range_key      = "id"
 
-    autoscaling_read = {
-        max_capacity      = 600
-      }
+  attribute {
+    name = "id"
+    type = "S"
+  }
 
-   autoscaling_write = {
-        max_capacity      = 600
-      }
+  attribute {
+    name = "target_id"
+    type = "S"
+  }
 
+  tags = {
+    Name              = "charges-api-${var.environment_name}"
+    Environment       = var.environment_name
+    terraform-managed = true
+    project_name      = var.project_name
+  }
 
-    attribute {
-        name              = "id"
-        type              = "S"
-    }
-	
-    attribute {
-        name              = "target_id"
-        type              = "S"
-    }
-
-    tags = {
-        Name              = "charges-api-${var.environment_name}"
-        Environment       = var.environment_name
-        terraform-managed = true
-        project_name      = var.project_name
-    }
-
-    point_in_time_recovery {
-        enabled           = true
-    }
+  point_in_time_recovery {
+    enabled = true
+  }
 }
+
+resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
+  max_capacity       = 600
+  min_capacity       = 100
+  resource_id        = "table/${aws_dynamodb_table.chargesapi_dynamodb_table.name}"
+  scalable_dimension = "dynamodb:table:ReadCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_policy" "dynamodb_table_read_policy" {
+  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_read_target.resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.dynamodb_table_read_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.dynamodb_table_read_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.dynamodb_table_read_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBReadCapacityUtilization"
+    }
+
+    target_value = 70
+  }
+}
+
+resource "aws_appautoscaling_target" "dynamodb_table_write_target" {
+  max_capacity       = 600
+  min_capacity       = 100
+  resource_id        = "table/${aws_dynamodb_table.chargesapi_dynamodb_table.name}"
+  scalable_dimension = "dynamodb:table:WriteCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_policy" "dynamodb_table_write_policy" {
+  name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_write_target.resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.dynamodb_table_write_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.dynamodb_table_write_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.dynamodb_table_write_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBWriteCapacityUtilization"
+    }
+
+    target_value = 70
+  }
+}
+


### PR DESCRIPTION
## What
- Add autoscaling to dynamodb terraform script

## Why
- This is to allow the read/write capacity of the table to match the demand to the maximum specified.  This way the read/write capacity is increased only as and when needed.